### PR TITLE
Remove provided scopes from poms

### DIFF
--- a/starter-microservice-test/repository/provided-pom.xml
+++ b/starter-microservice-test/repository/provided-pom.xml
@@ -27,7 +27,6 @@
             <groupId>javax.websocket</groupId>
             <artifactId>javax.websocket-api</artifactId>
             <version>1.1</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/starter-microservice-websocket/repository/provided-pom.xml
+++ b/starter-microservice-websocket/repository/provided-pom.xml
@@ -27,7 +27,6 @@
             <groupId>javax.websocket</groupId>
             <artifactId>javax.websocket-api</artifactId>
             <version>1.1</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Remove provided scopes from poms as the scope is set when we pull them in.