### PR TITLE
fix(scrollify): set height on technology list, override scroll overlord

### DIFF
--- a/liberty-starter-application/src/main/webapp/css/style.css
+++ b/liberty-starter-application/src/main/webapp/css/style.css
@@ -133,6 +133,10 @@ body {
 	margin-bottom: 120px;
 }
 
+#step1 .stepContent {
+	height: 700px;
+}
+
 #banner {
 	position: relative;
 	height: 236px;


### PR DESCRIPTION
After a billion tries modifying the javascript file to fix the issue that Alasdair mentioned, I found a much simpler solution by modifying the CSS. If you set a fixed height on the container wrapping the list of technologies, the scrollify plugin has to accommodate for the fixed height when calculating the height for the section. The pixel height selected is just a guess-timate that worked across Chrome, Firefox, and Safari.