### PR TITLE
Payload change - install liberty from maven central

### DIFF
--- a/liberty-starter-application/skeletons/base/myProject-wlpcfg/pom.xml
+++ b/liberty-starter-application/skeletons/base/myProject-wlpcfg/pom.xml
@@ -67,9 +67,15 @@
                         <default.http.port>${testServerHttpPort}</default.http.port>
                         <default.https.port>${testServerHttpsPort}</default.https.port>
                     </bootstrapProperties>
-                    <install />
                 </configuration>
                 <executions>
+                    <execution>
+                        <id>intall-liberty</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>install-server</goal>
+                        </goals>
+                    </execution>
                     <execution>
                         <id>start-server</id>
                         <phase>pre-integration-test</phase>

--- a/liberty-starter-application/skeletons/specialFiles/pom.xml
+++ b/liberty-starter-application/skeletons/specialFiles/pom.xml
@@ -157,7 +157,13 @@
                     <version>1.2</version>
                     <extensions>true</extensions>
                     <configuration>
-                            <serverName>${wlpServerName}</serverName>
+                        <serverName>${wlpServerName}</serverName>
+                        <assemblyArtifact>
+                            <groupId>com.ibm.websphere.appserver.runtime</groupId>
+                            <artifactId>wlp-webProfile7</artifactId>
+                            <version>16.0.0.2</version>
+                            <type>zip</type>
+                        </assemblyArtifact>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Add config to pull in Liberty webProfile7 version 16.0.0.2 from Maven Central. Change to new install method, explicitly calling out install-server goal rather than using the install configuration option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wasdev/tool.accelerate.core/61)
<!-- Reviewable:end -->
