### PR TITLE
Switch back to running on 16002 for persistence

### DIFF
--- a/common-war.gradle
+++ b/common-war.gradle
@@ -36,7 +36,7 @@ war {
 
 liberty {
     install {
-        runtimeUrl = "http://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-javaee7/16.0.0.3/wlp-javaee7-16.0.0.3.zip"
+        runtimeUrl = "http://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-javaee7/16.0.0.2/wlp-javaee7-16.0.0.2.zip"
     }
     serverName = 'StarterServer'
     userDir = "${buildDir}/test/wlp"


### PR DESCRIPTION
The persistence WAR won't deploy on 16003 (Liberty defect open for this)
so deploy to 16002 instead

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wasdev/tool.accelerate.core/71)
<!-- Reviewable:end -->
