### PR TITLE
Change ms-builder provided pom dependency to type pom

### DIFF
--- a/starter-microservice-ms-builder/repository/0.1/provided-pom.xml
+++ b/starter-microservice-ms-builder/repository/0.1/provided-pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>net.wasdev.wlp.starters.microprofile</groupId>
             <artifactId>provided-pom</artifactId>
-            <type>xml</type>
+            <type>pom</type>
             <version>0.0.3</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Change ms-builder provided pom dependency to type pom to download microprofile provided pom properly.

Signed-off-by: Kate Stanley <katheris@uk.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wasdev/tool.accelerate.core/166)
<!-- Reviewable:end -->
