### PR TITLE
Make sure the 0.0.4 pom info is pulled into the maven repository

### DIFF
--- a/starter-microservice-swagger/build.gradle
+++ b/starter-microservice-swagger/build.gradle
@@ -32,7 +32,7 @@ buildutils {
 
 task installAllPOMs(type: MavenTask) {
 	id 'swagger'
-	def String[] localVersion = ['0.0.1', '0.0.2', '0.0.3']
+	def String[] localVersion = ['0.0.1', '0.0.2', '0.0.3', '0.0.4']
 	pomVersion localVersion
 	hasProvided true
 	hasRuntime true

--- a/starter-microservice-swagger/repository/0.0.4/runtime-pom.xml
+++ b/starter-microservice-swagger/repository/0.0.4/runtime-pom.xml
@@ -28,7 +28,7 @@
             <groupId>net.wasdev.wlp.starters.swagger</groupId>
             <artifactId>server-snippet</artifactId>
             <type>xml</type>
-            <version>0.0.3</version>
+            <version>0.0.4</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Thanks to a colleague discovered that the 0.0.4 version of the pom dependencies which the generated project depends on are not actually available in the maven repository. I think the update to the build.gradle file should fix that. It would be good if the test had caught this, but I'll work that out later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wasdev/tool.accelerate.core/172)
<!-- Reviewable:end -->
