### PR TITLE
fix(build): Fix FileUploadTest

### DIFF
--- a/liberty-starter-application/src/test/java/com/ibm/liberty/starter/it/api/v1/FileUploadTest.java
+++ b/liberty-starter-application/src/test/java/com/ibm/liberty/starter/it/api/v1/FileUploadTest.java
@@ -143,7 +143,6 @@ public class FileUploadTest {
                                     foundInstallNode = true;
                                     Node config = ((Element) execution).getElementsByTagName("configuration").item(0);
                                     Node features = ((Element) config).getElementsByTagName("features").item(0);
-                                    assertTrue("Install feature was not found : apiDiscovery-1.0", hasChildNode(features, "feature", "apiDiscovery-1.0"));
                                     assertTrue("acceptLicense node with property true was not found", hasChildNode(features, "acceptLicense", "true"));
                                     foundFeaturesToInstall = true;
                                 }


### PR DESCRIPTION
Since java-generator version 3.1, liberty features are installed from server.xml and do not
need to configure in the maven or gradle plugin

Signed-off-by: Patrick Tiu <tiu@ca.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wasdev/tool.accelerate.core/211)
<!-- Reviewable:end -->
